### PR TITLE
Add a Verbose flag to Server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,7 @@ type Config struct {
 	Reverse   bool
 	KeepAlive time.Duration
 	TLS       TLSConfig
+	Verbose   bool
 }
 
 // Server respresent a chisel service
@@ -59,7 +60,7 @@ func NewServer(c *Config) (*Server, error) {
 		Logger:     cio.NewLogger("server"),
 		sessions:   settings.NewUsers(),
 	}
-	server.Info = true
+	server.Info = c.Verbose
 	server.users = settings.NewUserIndex(server.Logger)
 	if c.AuthFile != "" {
 		if err := server.users.LoadUsers(c.AuthFile); err != nil {


### PR DESCRIPTION
This makes the Chisel server use a verbosity flag, in a similar way to the client.